### PR TITLE
Use ceph-mon role to create ceph pools and users

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -94,3 +94,6 @@ maas_filesystem_critical_threshold: 90.0
 #   - { package: "libvirt-bin", version: "1.2.2-0ubuntu13.1.9" }
 #   - { package: "rabbitmq-server", origin: "www.rabbitmq.com" }
 #   - { package: "*", release: "MariaDB" }
+
+# Ceph
+openstack_config: true

--- a/rpcd/playbooks/ceph.yml
+++ b/rpcd/playbooks/ceph.yml
@@ -32,21 +32,3 @@
   user: root
   roles:
   - ceph-osd
-
-- name: Create users and pools
-  hosts: mons[0]
-  tasks:
-    # NOTE: this was ripped from http://ceph.com/docs/master/rbd/rbd-openstack/ without much consideration
-    # TODO: add proper guards so none of this is re-executed when this has already been executed
-    - command: ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
-      when: "{{ cephx|default(true) }}"
-    - command: ceph auth get-or-create client.glance mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=images'
-      when: "{{ cephx|default(true) }}"
-    - command: ceph auth get-or-create client.cinder-backup mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=backups'
-      when: "{{ cephx|default(true) }}"
-    - command: ceph osd pool create {{ item.name }} {{ item.pg_num }}
-      with_items:
-        - { name: 'volumes', pg_num: 128 }
-        - { name: 'images', pg_num: 128 }
-        - { name: 'backups', pg_num: 128 }
-        - { name: 'vms', pg_num: 128 }


### PR DESCRIPTION
Currently there is a separate play in the ceph playbook to create the
pools and users required by OpenStack. This commit removes that play and
sets openstack_config to true so that the ceph-mon role will do the
required configuration.
