### PR TITLE
Ceph environment change

### DIFF
--- a/rpcd/etc/openstack_deploy/conf.d/ceph.yml.aio
+++ b/rpcd/etc/openstack_deploy/conf.d/ceph.yml.aio
@@ -1,5 +1,8 @@
-ceph_hosts:
+mons_hosts:
   aio1:
     ip: 172.29.236.100
     affinity:
       ceph_mon_container: 3
+osds_hosts:
+  aio1:
+    ip: 172.29.236.100

--- a/rpcd/etc/openstack_deploy/env.d/ceph.yml
+++ b/rpcd/etc/openstack_deploy/env.d/ceph.yml
@@ -25,14 +25,14 @@ component_skel:
 container_skel:
   ceph_mon_container:
     belongs_to:
-      - ceph_containers
+      - mons_containers
     contains:
       - mons
     properties:
       container_release: trusty
   ceph_osd_container:
     belongs_to:
-      - ceph_containers
+      - osds_containers
     contains:
       - osds
     properties:
@@ -41,9 +41,15 @@ container_skel:
 
 
 physical_skel:
-  ceph_containers:
+  osds_containers:
     belongs_to:
       - all_containers
-  ceph_hosts:
+  osds_hosts:
+    belongs_to:
+      - hosts
+  mons_containers:
+    belongs_to:
+      - all_containers
+  mons_hosts:
     belongs_to:
       - hosts


### PR DESCRIPTION
This commit defines two kinds of ceph host to allow mons and osds to be
kept separate.
