### PR TITLE
Update SHAs for ceph-related roles

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -1,9 +1,9 @@
 - name: ceph-common
   src: https://github.com/ceph/ansible-ceph-common
-  version: 92da3177c72d6d3541e52277d54bb210e7745973
+  version: 8af8f0a4a5c18d33b95a148bf8da5e681fdeaca4
 - name: ceph-mon
   src: https://github.com/ceph/ansible-ceph-mon
-  version: 67d3ab89d13392183cc117cfcf5979c371c9ceb1
+  version: d6b6e980a3e2bf3dec26937c4dc1bc93e502290b
 - name: ceph-osd
   src: https://github.com/ceph/ansible-ceph-osd
-  version: bef4eef7107291d256c53322c66bfdf191a3e233
+  version: 53653e63317fb9a0b8cdb716913706ed11ffc2b5


### PR DESCRIPTION
This patch updates the SHAs for ansible-ceph-common, ansible-ceph-mon
and ansible-ceph-osd to the HEAD of the master branches.
