### PR TITLE
Set more appropriate defaults for pool sizes

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -99,3 +99,12 @@ maas_filesystem_critical_threshold: 90.0
 ceph_stable: true
 ceph_stable_release: hammer
 openstack_config: true
+raw_multi_journal: true
+journal_size: 80000
+pool_default_size: 3
+pool_default_min_size: 2
+mon_osd_full_ratio: .90
+mon_osd_nearfull_ratio: .80
+secure_cluster: true
+secure_cluster_flags:
+  - nodelete

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,6 +54,7 @@ if [[ "${DEPLOY_AIO}" == "yes" ]]; then
       echo "journal_size: 5120" | tee -a $RPCD_VARS
       echo "monitor_interface: eth1" | tee -a $RPCD_VARS
       echo "public_network: 172.29.236.0/22" | tee -a $RPCD_VARS
+      echo "raw_multi_journal: false" | tee -a $RPCD_VARS
       echo "osd_directory: true" | tee -a $RPCD_VARS
       echo "osd_directories:" | tee -a $RPCD_VARS
       echo "  - /var/lib/ceph/osd/mydir1" | tee -a $RPCD_VARS


### PR DESCRIPTION
This commit sets the following in user_extras_variables.yml:

pool_default_size: 3
pool_default_min_size: 2
mon_osd_full_ratio: .90
mon_osd_nearfull_ratio: .80
raw_multi_journal: true
journal_size: 80000

The role defaults are:

pool_default_size: 2
pool_default_min_size: 1
mon_osd_full_ratio: .95
mon_osd_nearfull_ratio: .85
raw_multi_journal: false
journal_size: 0

Additionally, we update scripts/deploy.sh to set raw_multi_journal when
running in an AIO since we're using osd directories here.
