### PR TITLE
Fix logging for Ceph

### DIFF
--- a/rpcd/etc/openstack_deploy/env.d/ceph.yml
+++ b/rpcd/etc/openstack_deploy/env.d/ceph.yml
@@ -30,6 +30,7 @@ container_skel:
       - mons
     properties:
       container_release: trusty
+      service_name: ceph
   ceph_osd_container:
     belongs_to:
       - osds_containers
@@ -38,6 +39,7 @@ container_skel:
     properties:
       is_metal: true
       container_release: trusty
+      service_name: ceph
 
 
 physical_skel:

--- a/rpcd/playbooks/ceph.yml
+++ b/rpcd/playbooks/ceph.yml
@@ -30,5 +30,27 @@
 - name: Deploy osds
   hosts: osds
   user: root
+  pre_tasks:
+  - name: Create log dir
+    file:
+      path: "{{ item.path }}"
+      state: directory
+    with_items:
+      - { path: "/openstack/log/{{ inventory_hostname }}-ceph" }
+    when: is_metal | bool
+    tags:
+      - ceph-logs
+      - ceph-log-dirs
+  - name: Create log aggregation links
+    file:
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+      state: "{{ item.state }}"
+      force: "yes"
+    with_items:
+      - { src: "/openstack/log/{{ inventory_hostname }}-ceph", dest: "/var/log/ceph", state: "link" }
+    when: is_metal | bool
+    tags:
+      - ceph-logs
   roles:
   - ceph-osd


### PR DESCRIPTION
Ensure the /var/log/ceph directory is bind mounted appropriately inside
the ceph containers, and create the /openstack/log/{{ inventory_hostname
}}-ceph directory with a symlink to /var/log/ceph for is_metal: True
ceph hosts.
