### PR TITLE
Lock ceph fsid

### DIFF
--- a/rpcd/etc/openstack_deploy/user_extras_secrets.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_secrets.yml
@@ -17,3 +17,4 @@ maas_keystone_password:
 rpc_support_holland_password:
 kibana_password:
 maas_rabbitmq_password:
+fsid_uuid:

--- a/rpcd/etc/openstack_deploy/user_extras_variables.yml
+++ b/rpcd/etc/openstack_deploy/user_extras_variables.yml
@@ -96,6 +96,7 @@ maas_filesystem_critical_threshold: 90.0
 #   - { package: "*", release: "MariaDB" }
 
 # Ceph
+fsid: '{{ fsid_uuid }}'
 ceph_stable: true
 ceph_stable_release: hammer
 openstack_config: true


### PR DESCRIPTION
This commit adds fsid_uuid to user_extras_secrets.yml and then points
fsid to fsid_uuid.  The ceph roles use fsid variable but we need
fsid_uuid for pw-token-gen.py to auto-generate a UUID.
