### PR TITLE
Remove rbd pool if it exists and is empty

### DIFF
--- a/rpcd/playbooks/ceph-mon.yml
+++ b/rpcd/playbooks/ceph-mon.yml
@@ -19,3 +19,19 @@
   max_fail_percentage: 0
   roles:
     - ceph-mon
+  tasks:
+    - name: Check if rbd pool exists and is empty
+      shell: rados -p rbd df | egrep '^rbd( +0){9}$'
+      run_once: true
+      ignore_errors: true
+      register: rbd_pool_exists
+
+    - name: Unset nodelete flag on rbd pool
+      command: ceph osd pool set rbd nodelete 0
+      run_once: true
+      when: rbd_pool_exists.rc == 0
+
+    - name: Remove rbd pool if it exists and is empty
+      command: ceph osd pool delete rbd rbd --yes-i-really-really-mean-it
+      run_once: true
+      when: rbd_pool_exists.rc == 0


### PR DESCRIPTION
The rbd pool is created automatically when a new Ceph cluster is
deployed. This pool is not used by an OpenStack deployment by does
consume pgs and so should be removed.
